### PR TITLE
Fix unmatching

### DIFF
--- a/sphinxval/utils/classes.py
+++ b/sphinxval/utils/classes.py
@@ -1864,7 +1864,7 @@ class SPHINX:
         self.observed_all_clear.all_clear_boolean = True
         
         #Uses thresholds from self.thresholds as keys
-        self.sep_match_status = "Unmatched"
+        self.sep_match_status[thresh_key] = "Unmatched"
         self.observed_probability[thresh_key].probability_value = 0.0
         self.observed_threshold_crossing[thresh_key] = Threshold_Crossing(None, None, None, None)
         self.observed_event_length[thresh_key] = Event_Length(None, None, None, None)

--- a/sphinxval/utils/match.py
+++ b/sphinxval/utils/match.py
@@ -3,7 +3,7 @@ from . import object_handler as objh
 from . import classes as cl
 import sys
 import pandas as pd
-
+import numpy as np
 
 __version__ = "0.1"
 __author__ = "Katie Whitman"
@@ -1993,13 +1993,19 @@ def revise_eruption_matches(matched_sphinx, all_energy_channels, obs_values,
                         
                         obs_idx = [ix for ix in range(len(matched_obs[j])) if matched_obs[j][ix].source == sep_source[j]]
                         td_eruptions.append(td_eruptions_array[j][obs_idx[0]])
+
+                    td_eruptions = np.array(td_eruptions, dtype='float') # Turn None into nan
                     
                     #Need to find which eruption is the closest
                     #to the SEP event and unmatch all the other forecasts
                     #Since all the time differences are necessarily negative,
                     #the max time will be the one closest to the SEP event
                     #and the preferable match
-                    best_eruption = max(td_eruptions)
+                    #
+                    # TODO: fix the ugly hack to cast to np array to handle None values entered from above
+                    #best_eruption = max(td_eruptions)
+                    best_eruption = np.nanmax(td_eruptions)
+
 
                     #If all the time differences are the same, then the
                     #same eruption was used in the forecasts and nothing
@@ -2009,6 +2015,7 @@ def revise_eruption_matches(matched_sphinx, all_energy_channels, obs_values,
 
                     #The eruptions and forecasts to unmatch
                     #Get back to the indices associated with the sphinx objects
+                    # Note that if td_eruptions[ix] is nan the index will never be added
                     adj_idx = [ix for ix in range(len(td_eruptions)) if td_eruptions[ix] < best_eruption]
                     sphx_idx = []
                     for ix in adj_idx:

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -920,10 +920,9 @@ def threshold_crossing_intuitive_metrics(df, dict, model, energy_key,
 
     obs = sub['Observed SEP Threshold Crossing Time'].to_list()
     pred = sub['Predicted SEP Threshold Crossing Time'].to_list()
-    td = (sub['Predicted SEP Threshold Crossing Time'] - sub['Observed SEP Threshold Crossing Time']) #.to_list()
+    td = (sub['Predicted SEP Threshold Crossing Time'] - sub['Observed SEP Threshold Crossing Time'])
     print(obs)
     print(pred)
-    
     td = td.dt.total_seconds()/(60*60) #convert to hours
     td = td.to_list()
     abs_td = [abs(x) for x in td]
@@ -963,7 +962,7 @@ def start_time_intuitive_metrics(df, dict, model, energy_key, thresh_key):
 
     obs = sub['Observed SEP Start Time'].to_list()
     pred = sub['Predicted SEP Start Time'].to_list()
-    td = (sub['Predicted SEP Start Time'] - sub['Observed SEP Start Time']).to_list()
+    td = (sub['Predicted SEP Start Time'] - sub['Observed SEP Start Time'])
     print(obs)
     print(pred)
     
@@ -1006,8 +1005,8 @@ def end_time_intuitive_metrics(df, dict, model, energy_key,
     write_df(sub, "end_time_selections_" + model + "_" + energy_key.strip() + "_" + thresh_fnm)
 
     obs = sub['Observed SEP End Time'].to_list()
-    pred = sub['Predicted End Time'].to_list()
-    td = (sub['Predicted End Time'] - sub['Observed End Time']).to_list()
+    pred = sub['Predicted SEP End Time'].to_list()
+    td = (sub['Predicted SEP End Time'] - sub['Observed SEP End Time'])
     print(obs)
     print(pred)
     
@@ -1102,7 +1101,7 @@ def peak_intensity_time_intuitive_metrics(df, dict, model, energy_key,
 
     obs = sub['Observed SEP Peak Intensity (Onset Peak) Time'].to_list()
     pred = sub['Predicted SEP Peak Intensity (Onset Peak) Time'].to_list()
-    td = (sub['Predicted SEP Peak Intensity (Onset Peak) Time'] - sub['Observed SEP Peak Intensity (Onset Peak) Time'])#.to_list()
+    td = (sub['Predicted SEP Peak Intensity (Onset Peak) Time'] - sub['Observed SEP Peak Intensity (Onset Peak) Time'])
     print(obs)
     print(pred)
     
@@ -1148,7 +1147,7 @@ def peak_intensity_max_time_intuitive_metrics(df, dict, model, energy_key,
 
     obs = sub['Observed SEP Peak Intensity Max (Max Flux) Time'].to_list()
     pred = sub['Predicted SEP Peak Intensity Max (Max Flux) Time'].to_list()
-    td = (sub['Predicted SEP Peak Intensity Max (Max Flux) Time'] - sub['Observed SEP Peak Intensity Max (Max Flux) Time']).to_list()
+    td = (sub['Predicted SEP Peak Intensity Max (Max Flux) Time'] - sub['Observed SEP Peak Intensity Max (Max Flux) Time'])
     print(obs)
     print(pred)
     


### PR DESCRIPTION
Fix unmatching bugs encountered when processing SEPVAL UMASEP.

Exception appears to be encountered because a mixture of triggered forecasts and forecasts without observation are encountered.

No changes to unmatching logic.  Did not verify that unmatching is done correctly.