### PR TITLE
Added check_json.py

### DIFF
--- a/bin/check_json.py
+++ b/bin/check_json.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+import os.path
+import argparse
+import json
+import traceback
+import sphinxval.utils.validation_json_handler as vjson
+
+description = """
+Checks a series of CCMC Scoreboard forecast jsons or SPHINX
+observation jsons for compatibility with the SPHINX validation tool.
+For each json file given to the input (see arguments), prints OK for
+jsons passing all tests, and ERROR for jsons that have a problem,
+followed by a printout of the file/json.
+"""
+
+epilog = """
+If jsons are given both as an argument list and as a file containing a
+list (e.g. both --ModelList and --model), then the argument list is
+appended to end of the file list.
+"""
+
+parser = argparse.ArgumentParser(description=description, epilog=epilog)
+parser.add_argument("--ModelList",
+        help="File contining a list of prediction json files.")
+parser.add_argument("--DataList",
+        help="File containing a list of observation json files.")
+parser.add_argument("--model", nargs="*",  default=[],
+                    help="Command-line list of prediction jsons files")
+parser.add_argument("--data", nargs="*", default=[],
+                    help="Command-line list of observation  jsons files")
+parser.add_argument("--dontstop", action="store_true", default=False,
+                    help="Don't stop checking jsons on ERROR")
+parser.add_argument("--print", action="store_true", default=False,
+                    help="Print each json even when OK")
+args = parser.parse_args()
+
+# Prepare lists of json files
+if args.ModelList:
+    model_list = vjson.read_list_of_jsons(args.ModelList)
+else:
+    model_list = []
+model_list.extend(args.model)
+
+if args.DataList:
+    data_list = vjson.read_list_of_jsons(args.DataList)
+else:
+    data_list = []
+data_list.extend(args.data)
+
+def maybe_stop():
+    if not args.dontstop:
+        exit()
+
+def print_json(json_fname, json_pretty):
+    print()
+    print(f"=== {json_fname} ===")
+    print(json_pretty)
+    print()
+    
+def check_jsons(kind, json_list):
+    if kind == 'observation':
+        object_from_json = vjson.observation_object_from_json        
+    elif kind == 'forecast':
+        object_from_json = vjson.forecast_object_from_json        
+
+    for json_fname in json_list:
+        # Check if the file exists
+        if not os.path.isfile(json_fname):
+            print("ERROR", json_fname, "File not found")
+            maybe_stop()
+
+        # Try to read the file into a json object
+        try:
+            json_obj = vjson.read_json_list([json_fname], verbose=False)[0]
+            json_pretty = json.dumps(json_obj, indent=4) # Save pretty format; see below
+        except Exception as e:
+            print("ERROR", json_fname, "Failed to read json:", e)
+            print()
+            print(f"=== {json_fname} ===")
+            with open(json_fname, 'r') as f:
+                  print(f.read())
+            maybe_stop()
+            continue
+
+        # Try to extract energy channels from the json object
+        try:
+            all_energy_channels = vjson.identify_all_energy_channels([json_obj], kind)
+        except Exception as e:
+            print("ERROR", json_fname, "Failed to extract energy channel:", e)
+            print_json(json_fname, json_pretty)
+            maybe_stop()
+            continue
+
+        # Try to build object for each of the energy channels
+        errored = False
+        for channel in all_energy_channels:
+            try:
+                sphinx_obj = object_from_json(json_obj, channel)
+            except Exception as e:
+                print("ERROR", json_fname, f"Failed to load object (channel {channel}):", e)
+                print(traceback.format_exc())
+                print_json(json_fname, json_pretty)
+                maybe_stop()
+                errored = True
+                break
+
+            # Check if trigger timestamps are valid
+            if kind == 'forecast':
+                is_valid = sphinx_obj.valid_forecast(verbose=True)
+                if not is_valid:
+                    print("ERROR", json_fname, f"valid_forecast() = {is_valid}")
+                    print_json(json_fname, json_pretty)
+                    maybe_stop()
+                    errored = True
+                    break
+
+        if errored:
+            continue
+
+        # Report success
+        print("OK", json_fname)
+        if args.print:
+            # Note: printing a saved formatted string from above because
+            # one of the functions above changes the object type of json_obj
+            # TODO: is that an unwanted side-effect?
+            print_json(json_fname, json_pretty)
+        
+if data_list:
+    print("=== Checking observation jsons ===")
+    check_jsons('observation', data_list)
+    
+if model_list:
+    print("=== Checking forecast jsons ===")
+    check_jsons('forecast', model_list)

--- a/sphinxval/utils/classes.py
+++ b/sphinxval/utils/classes.py
@@ -1021,7 +1021,7 @@ class Forecast():
         return last_time
 
 
-    def valid_forecast(self, last_trigger_time, last_input_time):
+    def valid_forecast(self, verbose=False):
         """ Check that the triggers and inputs are at the same time of
             or before the start of the prediction window. The prediction
             window cannot start before the info required to make
@@ -1033,16 +1033,24 @@ class Forecast():
             
         Output:
         
-            Updated self.valid field
+            Updated self.valid field, or None if there is no trigger
         
         """
+        last_input_time = self.last_input_time()
+        last_eruption_time, last_trigger_time = self.last_trigger_time()
 
         if self.issue_time == None:
-            return
+            self.valid = None
+            if verbose:
+                print("Issue time not available.")
+            return self.valid
             
         if last_trigger_time == None and last_input_time == None:
-            return
-        
+            self.valid = None
+            if verbose:
+                print("Trigger timing data not available.")
+            return self.valid
+
         self.valid = True
         if last_trigger_time != None:
             if self.issue_time < last_trigger_time:
@@ -1052,7 +1060,13 @@ class Forecast():
             if self.issue_time < last_input_time:
                 self.valid = False
 
-        return
+        if verbose and not self.valid:
+            print("Invalid forecast. "
+                  "Issue time (" + str(self.issue_time) + ") must start after last "
+                  "trigger (" + str(last_trigger_time) + ") or input time ("
+                  + str(last_input_time) + ").")
+
+        return self.valid
 
 
     def print_forecast_values(self):

--- a/sphinxval/utils/match.py
+++ b/sphinxval/utils/match.py
@@ -2242,12 +2242,9 @@ def match_all_forecasts(all_energy_channels, model_names, obs_objs,
                 matched_sphinx[fcast.short_name]['uses_eruptions'] = True
 
             #Check that forecast prediction window is after last trigger/input
-            fcast.valid_forecast(last_trigger_time, last_input_time)
+            fcast.valid_forecast(verbose=True)
             if fcast.valid == False:
-                print("match_criteria_all_forecasts: Invalid forecast. "
-                    "Issue time (" + str(fcast.issue_time) + ") must start after last "
-                    "trigger (" + str(last_trigger_time) + ") or input time ("
-                    + str(last_input_time) + "). Skipping " + fcast.source)
+                print("match_criteria_all_forecasts: Skipping invalid " + fcast.source)
                 continue
                 
 

--- a/sphinxval/utils/validation_json_handler.py
+++ b/sphinxval/utils/validation_json_handler.py
@@ -201,7 +201,7 @@ def identify_all_energy_channels(all_json, kind):
             energy channels present in all_jsons
             
     """
-    if kind == 'obsservation':
+    if kind == 'observation':
         key1 = 'sep_observation_submission'
         key2 = 'observations'
     elif kind == 'forecast':


### PR DESCRIPTION
check_json.py is a command-line tool for verifying that forecast/observation jsons are valid and useable by SPHINX.  It currently checkst that

1. json can be loaded
2. energy channel blocks can be found
3. an object can be instantiated
4. forecast json trigger timestamps are valid

A few small changes to outside SPHINX code aided in making the checker able to validate jsons using exactly the same functions/methods that SPHINX uses to work:

 - Forecast.valid_forecast() now takes no arguments; relies solely on class data.  It also has a verbose flag for explaining why invalid states are reached
 - match.py now relies on valid_forecast() above to print its error messages
 - validation_json_handler module changes:
   - read_in_json() no longer warns and skips for file not found / corrupt json type exceptions.  Exceptions are just raised and SPHINX will now fail in these cases.
   - split read_json_list() into that and read_list_of_jsons(), the former processes a python list of str filenames, the latter reads file and returns a python list of str filenames.
   - identify_all_energy_channels() now works on either forecast or observation jsons, specified using the 'kind' argument

Fixes issue #21