### PR TITLE
Add support for ROC Curve

### DIFF
--- a/sphinxval/utils/metrics.py
+++ b/sphinxval/utils/metrics.py
@@ -1286,7 +1286,7 @@ def receiver_operator_characteristic(obs, pred, model_name):
     roc_auc = skl.auc(fpr, tpr) # Area under the curve 
     roc_curve_plt = skl.RocCurveDisplay(fpr=fpr, tpr=tpr, roc_auc=roc_auc,estimator_name=model_name)
     
-    # plt.show()
+    
 
 
     

--- a/sphinxval/utils/metrics.py
+++ b/sphinxval/utils/metrics.py
@@ -1285,13 +1285,6 @@ def receiver_operator_characteristic(obs, pred, model_name):
     fpr, tpr, thresholds = skl.roc_curve(obs, pred) # fpr: false positive rate, tpr: true positive rate, thresholds: Decreasing thresholds on the decision function used to compute fpr and tpr. 
     roc_auc = skl.auc(fpr, tpr) # Area under the curve 
     roc_curve_plt = skl.RocCurveDisplay(fpr=fpr, tpr=tpr, roc_auc=roc_auc,estimator_name=model_name)
-    
-    
-
-
-    
-
-
     return roc_auc, roc_curve_plt
 
 

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -1386,8 +1386,12 @@ def probability_intuitive_metrics(df, dict, model, energy_key, thresh_key,
     roc_auc, roc_curve_plt = metrics.receiver_operator_characteristic(obs, pred, model)
     
     roc_curve_plt.plot()
+    skill_line = np.linspace(0.0, 1.0, num=10) # Constructing a diagonal line that represents no skill/random guess
+    plt.plot(skill_line, skill_line, '--', label = 'Random Guess')
     figname = config.outpath + '/plots/ROC_curve_' \
             + model + "_" + energy_key.strip() + "_" + thresh_fnm
+    plt.legend(loc="lower right")
+    plt.show()
     roc_curve_plt.figure_.savefig(figname + ".pdf", dpi=300, bbox_inches='tight')
  
     plt.close(roc_curve_plt.figure_)

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -1390,15 +1390,13 @@ def probability_intuitive_metrics(df, dict, model, energy_key, thresh_key,
     plt.plot(skill_line, skill_line, '--', label = 'Random Guess')
     figname = config.outpath + '/plots/ROC_curve_' \
             + model + "_" + energy_key.strip() + "_" + thresh_fnm
+    if mismatch:
+            figname = figname + "_mm"
+    if validation_type != "" and validation_type != "All":
+            figname = figname + "_" + validation_type
     plt.legend(loc="lower right")
-    plt.show()
     roc_curve_plt.figure_.savefig(figname + ".pdf", dpi=300, bbox_inches='tight')
- 
     plt.close(roc_curve_plt.figure_)
-    
-    # plt.plot(obs, pred, 'o')
-    # plt.show()
-    
     
     #Save to dict (ultimately dataframe)
     dict['Model'].append(model)

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -14,6 +14,8 @@ import os.path
 import pandas as pd
 import datetime
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
+import sklearn.metrics as skl
+
 
 __version__ = "0.1"
 __author__ = "Katie Whitman"
@@ -614,10 +616,12 @@ def initialize_probability_dict():
             "Threshold": [],
             "Prediction Energy Channel": [],
             "Prediction Threshold": [],
+            'ROC Curve Plot': [],
             "Brier Score": [],
             "Brier Skill Score": [],
             "Linear Correlation Coefficient": [],
             "Rank Order Correlation Coefficient": [],
+            'Area Under ROC Curve': []
             }
             
     return dict
@@ -1376,8 +1380,21 @@ def probability_intuitive_metrics(df, dict, model, energy_key, thresh_key,
     #Calculate metrics
     brier_score = metrics.calc_brier(obs, pred)
     brier_skill = metrics.calc_brier_skill(obs, pred)
-    lin_corr_coeff = None
-    rank_corr_coeff = None
+    lin_corr_coeff, _ = metrics.calc_pearson(obs, pred) 
+    rank_corr_coeff, _ = metrics.calc_spearman(obs, pred)  
+
+    roc_auc, roc_curve_plt = metrics.receiver_operator_characteristic(obs, pred, model)
+    
+    roc_curve_plt.plot()
+    figname = config.outpath + '/plots/ROC_curve_' \
+            + model + "_" + energy_key.strip() + "_" + thresh_fnm
+    roc_curve_plt.figure_.savefig(figname + ".pdf", dpi=300, bbox_inches='tight')
+ 
+    plt.close(roc_curve_plt.figure_)
+    
+    # plt.plot(obs, pred, 'o')
+    # plt.show()
+    
     
     #Save to dict (ultimately dataframe)
     dict['Model'].append(model)
@@ -1385,10 +1402,12 @@ def probability_intuitive_metrics(df, dict, model, energy_key, thresh_key,
     dict['Threshold'].append(thresh_key)
     dict['Prediction Energy Channel'].append(pred_energy_key)
     dict['Prediction Threshold'].append(pred_thresh_key)
+    dict['ROC Curve Plot'].append(figname)
     dict['Brier Score'].append(brier_score)
     dict['Brier Skill Score'].append(brier_skill)
     dict['Linear Correlation Coefficient'].append(lin_corr_coeff)
     dict['Rank Order Correlation Coefficient'].append(rank_corr_coeff)
+    dict['Area Under ROC Curve'].append(roc_auc)
 
 
 def calc_all_flux_metrics(obs, pred):


### PR DESCRIPTION
Change in metrics.py and validation.py to support

ROC curve for probability models. ROC curve is output into a pdf plot that Luke will add to the html reports. Area under the roc curve is added as a metric into the probability metrics table. Added columns to probability_metrics.csv to accommodate the metric and plot.

More comments in metrics.py that define each metric and the various names they have, i.e. hit rate is also probability of detection, recall and sensitivity.