### PR TITLE
SPHINX creates output/ and report/ folders if they don't already exist

### DIFF
--- a/sphinxval/utils/report.py
+++ b/sphinxval/utils/report.py
@@ -754,7 +754,7 @@ def report(output_dir, relative_path_plots): ### ADD OPTIONAL ARGUMENT HERE
         files.remove('desktop.ini')
     files.sort()
    
-    if not os.path.exists(config.reportpath):
+    if not os.path.isdir(config.reportpath):
         os.mkdir(config.reportpath)
  
     # obtain sphinx dataframe

--- a/sphinxval/utils/report.py
+++ b/sphinxval/utils/report.py
@@ -753,7 +753,10 @@ def report(output_dir, relative_path_plots): ### ADD OPTIONAL ARGUMENT HERE
     if 'desktop.ini' in files:
         files.remove('desktop.ini')
     files.sort()
-    
+   
+    if not os.path.exists(config.reportpath):
+        os.mkdir(config.reportpath)
+ 
     # obtain sphinx dataframe
     sphinx_dataframe = pd.read_pickle(output_dir__ + 'SPHINX_dataframe.pkl')
 

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -391,6 +391,8 @@ def fill_dict_row(sphinx, dict, energy_key, thresh_key):
 
 
 def prepare_outdirs():
+    if not os.path.isdir(config.outpath):
+        os.mkdir(config.outpath)
     for datafmt in ('pkl', 'csv', 'plots'):
         outdir = os.path.join(config.outpath, datafmt)
         if not os.path.isdir(outdir):


### PR DESCRIPTION
SPHINX would fail upon first run if the `config.outpath` directory did not previously exist. When running in report-only mode, SPHINX will fail if the `config.reportpath` directory does not exist. This pull request fixes both issues.
