### PR TITLE
Pass SPHINX dataframe to reporting module when available

### DIFF
--- a/bin/sphinx.py
+++ b/bin/sphinx.py
@@ -21,5 +21,5 @@ parser.add_argument("--RelativePathPlots", type=bool, default=True, \
 
 args = parser.parse_args()
 
-sphinxval.sphinx.validate(args.DataList, args.ModelList, top=args.TopDirectory, Resume=args.Resume)
-sphinxval.sphinx.report.report(None, args.RelativePathPlots)
+sphinx_df = sphinxval.sphinx.validate(args.DataList, args.ModelList, top=args.TopDirectory, Resume=args.Resume)
+sphinxval.sphinx.report.report(None, args.RelativePathPlots, sphinx_dataframe=sphinx_df)

--- a/sphinxval/sphinx/sphinx.py
+++ b/sphinxval/sphinx/sphinx.py
@@ -58,7 +58,7 @@ def validate(data_list, model_list, top=None, Resume=None):
                 
         OUTPUT:
         
-            None
+            :sphinx_df: (pandas dataframe) SPHINX dataframe.
             
     """
     setup_logging()

--- a/sphinxval/sphinx/sphinx.py
+++ b/sphinxval/sphinx/sphinx.py
@@ -118,9 +118,11 @@ def validate(data_list, model_list, top=None, Resume=None):
 
 
     #Perform intuitive validation
-    valid.intuitive_validation(matched_sphinx, model_names,
+    sphinx_df = valid.intuitive_validation(matched_sphinx, model_names,
         all_energy_channels, all_observed_thresholds, observed_sep_events, profname_dict, r_df=r_df)
     logger.info("Completed validation.")
+    
+    return sphinx_df
 
 
     

--- a/sphinxval/utils/report.py
+++ b/sphinxval/utils/report.py
@@ -759,7 +759,7 @@ def embed_pdf_files_in_html(html_content, output_html_path):
 
  
 # FINAL RESULT
-def report(output_dir, relative_path_plots): ### ADD OPTIONAL ARGUMENT HERE
+def report(output_dir, relative_path_plots, sphinx_dataframe=None): ### ADD OPTIONAL ARGUMENT HERE
     global output_dir__
     global relative_path_plots__
 
@@ -781,7 +781,10 @@ def report(output_dir, relative_path_plots): ### ADD OPTIONAL ARGUMENT HERE
         os.mkdir(config.reportpath)
  
     # obtain sphinx dataframe
-    sphinx_dataframe = pd.read_pickle(os.path.join(output_dir__, 'SPHINX_dataframe.pkl'))
+    if sphinx_dataframe is None: 
+        sphinx_dataframe_location = os.path.join(output_dir__, 'SPHINX_dataframe.pkl')
+        logger.info('    No SPHINX dataframe supplied to reporting module. Using SPHINX dataframe saved at location ' + sphinx_dataframe_location)
+        sphinx_dataframe = pd.read_pickle(os.path.join(output_dir__, 'SPHINX_dataframe.pkl'))
 
     # grab all models
     models = list(set(sphinx_dataframe['Model']))

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -3610,7 +3610,7 @@ def intuitive_validation(matched_sphinx, model_names, all_energy_channels,
     
     Output:
     
-    
+        :df: (pandas dataframe) SPHINX dataframe. 
     
     """
     logger.info("Beginning validation process.")

--- a/sphinxval/utils/validation.py
+++ b/sphinxval/utils/validation.py
@@ -3650,4 +3650,6 @@ def intuitive_validation(matched_sphinx, model_names, all_energy_channels,
                 all_observed_thresholds, type)
  
     logger.info("intuitive_validation: Validation process complete.")
-    
+
+    return df   
+ 


### PR DESCRIPTION
Added return statements to `sphinx.validate()` and `validation.intuitive_validation()` to allow the passage of the SPHINX dataframe from the SPHINX validation module to the SPHINX reporting module. When running SPHINX's full validation protocol, the dataframe will be passed directly from the validation step to the reporting step. If the reporting module is run as a standalone code, the SPHINX dataframe will be read in from disk. Addresses Issue #141.