### PR TITLE
Fix crash when removing resume duplicates

### DIFF
--- a/sphinxval/sphinx/sphinx.py
+++ b/sphinxval/sphinx/sphinx.py
@@ -77,7 +77,7 @@ def validate(data_list, model_list, top=None, Resume=None):
 
     #Check for duplicates in the set of forecasts and remove any
     logger.info("Checking for and removing duplicate forecasts from the input Model List.")
-    model_objs, fcast_df = duplicates.remove_forecast_duplicates(all_energy_channels, model_objs)
+    model_objs = duplicates.remove_forecast_duplicates(all_energy_channels, model_objs)
 
     #Dictionary containing the location of all the .txt files
     #in the subdirectories below top.
@@ -101,7 +101,7 @@ def validate(data_list, model_list, top=None, Resume=None):
             + Resume)
         r_df = resume.read_in_df(Resume)
         
-        model_objs = duplicates.remove_resume_duplicates(r_df, fcast_df, model_objs)
+        model_objs = duplicates.remove_resume_duplicates(r_df, model_objs)
     ################
     
     

--- a/sphinxval/utils/duplicates.py
+++ b/sphinxval/utils/duplicates.py
@@ -321,32 +321,27 @@ def remove_forecast_duplicates(all_energy_channels, model_objs):
     
     """
     
-    fcast_df = {}
-
     for energy_key in all_energy_channels:
         df = fill_forecast_df(model_objs[energy_key])
 
         #Check for duplicated forecasts and remove
         df, dup_indices = identify_forecast_duplicates(df)
-        fcast_df.update({energy_key: df})
 
         for i in sorted(dup_indices, reverse=True):
             logger.warning(f"DUPLICATE INPUT FORECAST: Removing duplicated forecast for energy channel {energy_key},  {model_objs[energy_key][i].source}")
             model_objs[energy_key].pop(i)
         
-    return model_objs, fcast_df
+    return model_objs
 
 
 
-def remove_resume_duplicates(r_df, fcast_df, model_objs):
+def remove_resume_duplicates(r_df, model_objs):
     """ Compare exact filenames in the resume dataframe with filenames
         in the dataframe of Forecast objects from model_objs
     
         INPUTS:
         
             :r_df: (pandas DataFrame) SPHINX_dataframe read back in from a previous run
-            :fcast_df: (dict of DataFrames) df sorted by energy channel containing the unique
-                forecasts read in to sphinx. Created in remove_forecast_duplicates().
             :model_objs: (dict of Forecast objects) unique forecast objects sorted by energy channel
             
         OUTPUTS:
@@ -357,7 +352,7 @@ def remove_resume_duplicates(r_df, fcast_df, model_objs):
     """
     
     for energy_key in model_objs.keys():
-        df = fcast_df[energy_key]
+        df = fill_forecast_df(model_objs[energy_key])
 
         df_dup = df[df['Forecast Source'].isin(r_df['Forecast Source'])]
         dup_indices = df_dup['Prediction Index'].to_list()


### PR DESCRIPTION
When both input duplicates and resume duplicates are present, sphinx would crash because the first duplicate removal changed the index order of the Forecast object array, which was saved and reused in a dataframe for the resume duplicate removal.

Changed to regenerate the Forecast object dataframe in remove_resume_duplicates() and remove existence of fcast_df passed from remove_forecast_duplicates().