### PR TITLE
Address issues #110 (logging) and #137 (resume)

### DIFF
--- a/bin/sphinx.py
+++ b/bin/sphinx.py
@@ -1,6 +1,11 @@
 import sphinxval.sphinx
 import argparse
-
+import logging
+import logging.config
+import os
+from sphinxval.utils import config as cfg
+import pathlib
+import json
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--ModelList", type=str, default='', \
@@ -18,8 +23,28 @@ parser.add_argument("--RelativePathPlots", type=bool, default=True, \
         help=("Generate reports with relative paths for plots"))
 
 
+#Create logger
+logger = logging.getLogger(__name__)
+
+
+def setup_logging():
+    # Create the logs/ directory if it does not yet exist
+    if not os.path.exists(cfg.logpath):
+        os.mkdir(cfg.logpath)
+
+    config_file = pathlib.Path('sphinxval/log/log_config.json')
+    with open(config_file) as f_in:
+        config = json.load(f_in)
+    logging.config.dictConfig(config)
+
 
 args = parser.parse_args()
 
-sphinx_df = sphinxval.sphinx.validate(args.DataList, args.ModelList, top=args.TopDirectory, Resume=args.Resume)
-sphinxval.sphinx.report.report(None, args.RelativePathPlots, sphinx_dataframe=sphinx_df)
+setup_logging()
+
+try:
+    sphinx_df = sphinxval.sphinx.validate(args.DataList, args.ModelList, top=args.TopDirectory, Resume=args.Resume)
+    sphinxval.sphinx.report.report(None, args.RelativePathPlots, sphinx_dataframe=sphinx_df)
+
+except:
+    logger.exception('SPHINX failed with an exception.')

--- a/sphinxval/utils/resume.py
+++ b/sphinxval/utils/resume.py
@@ -25,8 +25,9 @@ def read_in_df(filename):
         df = pickle.load(pklfile)
         return df
     except:
-        sys.exit("RESUME: Cannot open pickle file containing "
-            "input dataframe. Please check the filename.")
+        logger.error("Cannot open pickle file containing "
+            f"input dataframe. Please check the filename: {filename}")
+        sys.exit()
 
 
 


### PR DESCRIPTION
For issue #110, added a try except block at the very top level in bin/sphinx.py to capture exceptions in the log file rather that stdout.

For issue #137, moved the line to read in the resume dataframe before reading in the forecast and observation jsons to avoid wasting time when there is a problem with the resume dataframe.