### PR TITLE
Updated Validation Unit Tests for SPHINX not eval

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -992,7 +992,7 @@ class TestAllClear0(unittest.TestCase):
         forecast_json = './tests/files/forecasts/validation/all_clear/pred_all_clear_false.json'
         forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
         forecast_objects = {self.energy_key: [forecast]}
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
              self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
@@ -1004,7 +1004,7 @@ class TestAllClear0(unittest.TestCase):
         
     def step_1(self):
        
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
         for keywords in self.dataframe:            
             temp = utils.attributes_of_sphinx_obj(keywords, self.sphinx['Test_model_0'][self.all_energy_channels[0]][0],\
@@ -1082,7 +1082,7 @@ class TestAllClear1(unittest.TestCase):
         forecast_json = './tests/files/forecasts/validation/all_clear/pred_all_clear_true.json'
         forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
         forecast_objects = {self.energy_key: [forecast]}
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
              self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
@@ -1094,7 +1094,7 @@ class TestAllClear1(unittest.TestCase):
         
     def step_1(self):
         
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
         for keywords in self.dataframe:
             # temp = self.sphinx['Test_model_0'][self.energy_key].prediction.short_name\
@@ -1165,7 +1165,7 @@ class TestAllClearGarbage(unittest.TestCase):
             forecast_json = './tests/files/forecasts/validation/all_clear/pred_all_clear_garbage.json'
             forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
             forecast_objects = {self.energy_key: [forecast]}
-            self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+            self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
                 self.model_names, observation_objects, forecast_objects)
 
 
@@ -1192,7 +1192,7 @@ class TestPeakIntensity0(unittest.TestCase):
         forecast_json = './tests/files/forecasts/validation/onset_peak/pred_all_clear_false.json'
         forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
         forecast_objects = {self.energy_key: [forecast]}
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
              self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
@@ -1204,7 +1204,7 @@ class TestPeakIntensity0(unittest.TestCase):
         
     def step_1(self):
         
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
         for keywords in self.dataframe:
             # temp = self.sphinx['Test_model_0'][self.energy_key].prediction.short_name\
@@ -1285,7 +1285,7 @@ class TestPeakIntensityMult(unittest.TestCase):
         for jsons in forecast_json:
             forecast = utils.utility_load_forecast(jsons, self.energy_channel)
             forecast_objects[self.energy_key].append(forecast)
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
         
@@ -1295,7 +1295,7 @@ class TestPeakIntensityMult(unittest.TestCase):
         self.validation_type = ['All']
         
     def step_1(self):
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
        
         for keywords in self.dataframe:
@@ -1394,7 +1394,7 @@ class TestPeakIntensityMax0(unittest.TestCase):
         forecast_json = './tests/files/forecasts/validation/max_peak/pred_all_clear_false.json'
         forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
         forecast_objects = {self.energy_key: [forecast]}
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
              self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
@@ -1405,7 +1405,7 @@ class TestPeakIntensityMax0(unittest.TestCase):
         self.validation_type = ['All']
         
     def step_1(self):
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
         for keywords in self.dataframe:
         
@@ -1480,7 +1480,7 @@ class TestPeakIntensityMaxMult(unittest.TestCase):
         for jsons in forecast_json:
             forecast = utils.utility_load_forecast(jsons, self.energy_channel)
             forecast_objects[self.energy_key].append(forecast)
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
         
@@ -1499,7 +1499,7 @@ class TestPeakIntensityMaxMult(unittest.TestCase):
         Observed all clear is False
         Forecast all clear is False
         """
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
        
         for keywords in self.dataframe:
@@ -1589,7 +1589,7 @@ class TestProbability0(unittest.TestCase):
         forecast_json = './tests/files/forecasts/validation/probability/pred_probability_all_clear_false.json'
         forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
         forecast_objects = {self.energy_key: [forecast]}
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
              self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
@@ -1609,7 +1609,7 @@ class TestProbability0(unittest.TestCase):
         Observed all clear is False
         Forecast all clear is False
         """
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
         for keywords in self.dataframe:
             # temp = self.sphinx['Test_model_0'][self.energy_key].prediction.short_name\
@@ -1694,7 +1694,7 @@ class TestProbabilityMult(unittest.TestCase):
         for jsons in forecast_json:
             forecast = utils.utility_load_forecast(jsons, self.energy_channel)
             forecast_objects[self.energy_key].append(forecast)
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
         
@@ -1713,7 +1713,7 @@ class TestProbabilityMult(unittest.TestCase):
         Observed all clear is False
         Forecast all clear is False
         """
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
        
         for keywords in self.dataframe:
@@ -1806,7 +1806,7 @@ class TestShortNameChanger(unittest.TestCase):
         forecast_json = './tests/files/forecasts/validation/max_peak/pred_all_clear_false.json'
         forecast = utils.utility_load_forecast(forecast_json, self.energy_channel)
         forecast_objects = {self.energy_key: [forecast]}
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels,\
              self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
@@ -1817,7 +1817,7 @@ class TestShortNameChanger(unittest.TestCase):
         self.validation_type = ['All']
         
     def step_1(self):
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
         for keywords in self.dataframe:
             temp = utils.attributes_of_sphinx_obj(keywords, self.sphinx['new_shortname_for_testing'][self.all_energy_channels[0]][0],\
@@ -1894,7 +1894,7 @@ class Test_AllFields_MultipleForecasts(unittest.TestCase):
         for jsons in forecast_json:
             forecast = utils.utility_load_forecast(jsons, self.energy_channel)
             forecast_objects[self.energy_key].append(forecast)
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
         self.DoResume = False
         
@@ -1902,7 +1902,7 @@ class Test_AllFields_MultipleForecasts(unittest.TestCase):
             'peak_intensity_time', 'probability', 'start_time', 'threshold_crossing', 'time_profile']
         self.validation_type = ["All", "First", "Last", "Max", "Mean"]
 
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
        
         for keywords in self.dataframe:

--- a/tests/test_validation_mismatch.py
+++ b/tests/test_validation_mismatch.py
@@ -95,7 +95,7 @@ class Test_AllFields_Mismatch(unittest.TestCase):
         forecast_objects = {config_tests.mm_pred_ek: [], config_tests.mm_energy_key: []}
         
         self.all_energy_channels, observation_objects, forecast_objects = utils.utility_load_objects(observation_json, forecast_json)
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
         
 
         # Keeping this block but commenting out since it's useful for bugfixing
@@ -115,34 +115,43 @@ class Test_AllFields_Mismatch(unittest.TestCase):
         
         self.validation_type = ["All", "First", "Last", "Max", "Mean"]
 
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
-       
+        self.not_eval_dataframe = validate.fill_sphinx_df(self.not_eval_sphinx, \
+            self.obs_thresholds, self.profname_dict)
+        validate.write_df(self.dataframe, "SPHINX_dataframe")
+        validate.write_df(self.not_eval_dataframe, "not_eval_SPHINX")
+        
         for keywords in self.dataframe:
            
             logger.debug(len(self.sphinx['Test_model_0'][self.all_energy_channels[1]]))
             temp = utils.attributes_of_sphinx_obj(keywords, self.sphinx['Test_model_0'][self.all_energy_channels[1]][0],\
                  config_tests.mm_energy_key, self.obs_thresholds)#, self.pred_energy_key)
-            logger.debug('this is what should be equal - dataframe, temp, keywords')
-            logger.debug(self.dataframe[keywords][2])
-            logger.debug(temp)
-            logger.debug(keywords)
+            # logger.debug('this is what should be equal - dataframe, temp, keywords')
+            # logger.debug(self.dataframe[keywords][2])
+            # logger.debug(temp)
+            # logger.debug(keywords)
+            logger.debug(str(len(self.dataframe[keywords])))
             if 'SEP Fluence Spectrum' in keywords and "Units" not in keywords:
                 try:
                     
-                    for energies in range(len(self.dataframe[keywords][2])):
-                        self.assertEqual(self.dataframe[keywords][2][energies]['energy_min'], temp[energies]['energy_min'], 'Error is in keyword ' + keywords + ' energy_min')
-                        self.assertEqual(self.dataframe[keywords][2][energies]['energy_max'], temp[energies]['energy_max'], 'Error is in keyword ' + keywords + ' energy_max')
-                        self.assertEqual(self.dataframe[keywords][2][energies]['fluence'], temp[energies]['fluence'], 'Error is in keyword ' + keywords + ' fluence')
+                    for energies in range(len(self.dataframe[keywords][0])):
+                        self.assertEqual(self.dataframe[keywords][0][energies]['energy_min'], temp[energies]['energy_min'], 'Error is in keyword ' + keywords + ' energy_min')
+                        self.assertEqual(self.dataframe[keywords][0][energies]['energy_max'], temp[energies]['energy_max'], 'Error is in keyword ' + keywords + ' energy_max')
+                        self.assertEqual(self.dataframe[keywords][0][energies]['fluence'], temp[energies]['fluence'], 'Error is in keyword ' + keywords + ' fluence')
                 except:
                     
-                    self.assertTrue(pd.isna(self.dataframe[keywords][2]))
+                    self.assertTrue(pd.isna(self.dataframe[keywords][0]))
             elif keywords == 'All Threshold Crossing Times': 
                 pass
-            elif pd.isna(temp) and pd.isna(self.dataframe[keywords][2]):
-                self.assertTrue(pd.isna(self.dataframe[keywords][2]))
+            elif pd.isna(temp) and pd.isna(self.dataframe[keywords][0]):
+                self.assertTrue(pd.isna(self.dataframe[keywords][0]))
             else:
-                self.assertEqual(self.dataframe[keywords][2], temp, 'Error is in keyword ' + keywords)
+                logger.debug('this is what should be equal - dataframe, temp, keywords')
+                logger.debug(self.dataframe[keywords][0])
+                logger.debug(temp)
+                logger.debug(keywords)
+                self.assertEqual(self.dataframe[keywords][0], temp, 'Error is in keyword ' + keywords)
 
 
     def step_2(self):

--- a/tests/test_validation_resume.py
+++ b/tests/test_validation_resume.py
@@ -56,6 +56,7 @@ def mock_df_populate(dict):
     dict["Energy Channel Key"].append("min.10.0.max.-1.0.units.MeV")
     dict["Threshold Key"].append("threshold.1.0.units.1 / (cm2 s sr)")
     dict["Mismatch Allowed"].append(False)
+    dict['Evaluation Status'].append('Forecast is evaluated')
     dict["Prediction Energy Channel Key"].append("min.10.0.max.-1.0.units.MeV")
     dict["Prediction Threshold Key"].append("threshold.1.0.units.1 / (cm2 s sr)")
     dict["Forecast Source"].append("/home/m_sphinx/data/forecasts/enlil2.9e/2022/SEPMOD.20220402_000000.20220402_174512.20220402_172002/json/SEPMOD.2022-04-02T000000Z.2022-04-02T174804Z.json")
@@ -222,14 +223,14 @@ class Test_Resume(unittest.TestCase):
 
         self.pred_thresh_key = {self.pred_energy_key: [config_tests.mm_pred_tk]}
         
-        self.sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
+        self.sphinx, self.not_eval_sphinx, self.obs_thresholds, self.obs_sep_events = utils.utility_match_sphinx(self.all_energy_channels, self.model_names, observation_objects, forecast_objects)
         self.profname_dict = None
 
         
         
         self.validation_type = ["All", "First", "Last", "Max", "Mean"]
 
-        self.dataframe = validate.fill_sphinx_df(self.sphinx, self.model_names, self.all_energy_channels, \
+        self.dataframe = validate.fill_sphinx_df(self.sphinx,  \
             self.obs_thresholds, self.profname_dict)
        
         for keywords in self.dataframe:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -78,11 +78,11 @@ def utility_match_sphinx(all_energy_channels, model_names, obs_objs, model_objs)
 
     utility_setup_logging()
 
-    matched_sphinx, all_observed_thresholds, observed_sep_events =\
+    evaluated_sphinx, not_evaluated_sphinx, all_observed_thresholds, observed_sep_events =\
         match.match_all_forecasts(all_energy_channels, model_names,
             obs_objs, model_objs)
 
-    return matched_sphinx, all_observed_thresholds, observed_sep_events
+    return evaluated_sphinx, not_evaluated_sphinx, all_observed_thresholds, observed_sep_events
     
 def utility_get_verbosity():
     """
@@ -282,7 +282,8 @@ def attributes_of_sphinx_obj(keyword, sphinx_obj, energy_channel_key, threshold_
         return str(getattr(sphinx_obj.prediction, depth_prediction_string[keyword], None))
 
     depth_top = {
-        'Mismatch Allowed': 'mismatch'
+        'Mismatch Allowed': 'mismatch',
+        'Evaluation Status': 'not_evaluated'
     }
     if keyword in depth_top:
         return getattr(sphinx_obj, depth_top[keyword], None)


### PR DESCRIPTION
Updated unit tests to work with the new SPHINX workflow following not_evaluated updates. Tests will pass, but new unit tests will need to be built to actually test the not_evaluated output file, since that is a new output file - but this is out of the scope of this update.