### PR TITLE
Forecast report ongoing event status not evaluated

### DIFF
--- a/sphinxval/utils/classes.py
+++ b/sphinxval/utils/classes.py
@@ -179,7 +179,7 @@ class Particle_Intensity:
         self.observatory = observatory
         self.instrument = instrument
         self.last_data_time = last_data_time
-        self.ongoing_events = ongoing_events
+        self.ongoing_events = ongoing_events #array of dict
         
         return
         

--- a/sphinxval/utils/validation_json_handler.py
+++ b/sphinxval/utils/validation_json_handler.py
@@ -256,18 +256,12 @@ def forecast_object_from_json(fcast_json, energy_channel):
         return fcast, is_good_fcast
     
     is_good_trig = fcast.add_triggers_from_dict(fcast_json)
-    if not is_good_trig:
-        logger.warning(f"Note that there was an issue with the trigger block. {fcast_json['filename']}, {key}")
     
     is_good_input = fcast.add_inputs_from_dict(fcast_json)
-    if not is_good_input:
-        logger.warning(f"Note that there was an issue with the input block. {fcast_json['filename']}, {key}")
 
     fcast.check_energy_channel_format()
     
-    is_good = (is_good_fcast and is_good_trig and is_good_input)
-    
-    return fcast, is_good
+    return fcast, is_good_fcast
 
 
 def energy_channel_overlap(json, short_name, all_energy_channels):


### PR DESCRIPTION
The particle_intensities block in the SEP Scoreboard forecast jsons can contain a field called ongoing_events where a model can report that it is aware that an SEP event is in progress. Forecasts that indicate an event is ongoing will be removed from the analysis so that they are neither credited or penalized. These forecasts will be found in the SPHINX_removed dataframe.

The UMASEP model is currently the only model that does this.