### PR TITLE
Post analysis tool - manual run

### DIFF
--- a/bin/post_analysis.py
+++ b/bin/post_analysis.py
@@ -57,7 +57,7 @@ parser.add_argument("--showplot",
         help=("Show plots to screen."),
         action="store_true")
 parser.add_argument('--manual_run', type=str, default = '', 
-        help=("Use to run sphinx for an already existing sphinx dataframe"))
+        help=("Use to run sphinx for an already existing sphinx dataframe, this is the path to that file"))
 
 
 args = parser.parse_args()

--- a/bin/post_analysis.py
+++ b/bin/post_analysis.py
@@ -56,6 +56,8 @@ parser.add_argument("--saveplot",
 parser.add_argument("--showplot",
         help=("Show plots to screen."),
         action="store_true")
+parser.add_argument('--manual_run', type=str, default = '', 
+        help=("Use to run sphinx for an already existing sphinx dataframe"))
 
 
 args = parser.parse_args()
@@ -71,13 +73,17 @@ highlight = args.Highlight
 scoreboard = args.Scoreboard
 saveplot = args.saveplot
 showplot = args.showplot
+manual_run = args.manual_run
 
 exclude = args.Exclude.strip().split(",")
 include = args.Include.strip().split(",")
 
-bin = args.EnergyBin.strip().split(",")
-energy_min = float(bin[0])
-energy_max = float(bin[1])
+# bin = args.EnergyBin.strip().split(",")
+# energy_min = float(bin[0])
+# energy_max = float(bin[1])
+
+
+
 
 if acfa_filename != '':
     pa.export_all_clear_incorrect(acfa_filename, threshold, doplot=True)
@@ -101,4 +107,9 @@ if quantity != '':
     df = pa.read_in_metrics(path, quantity, include, exclude)
     pa.make_box_plots(df, path, quantity, anonymous, highlight, scoreboard,
         saveplot, showplot)
+
+if manual_run != '':
+    sphinx_filename = manual_run
+    print(sphinx_filename)
+    pa.manual_sphinx(sphinx_filename)
 

--- a/sphinxval/utils/post_analysis.py
+++ b/sphinxval/utils/post_analysis.py
@@ -2544,4 +2544,37 @@ def make_histograms():
     return
 
 
-make_histograms()
+def manual_sphinx(sphinx_file):
+    '''
+    Writing a sub-routine that will run SPHINX validation suite for a pre-existing SPHINX dataframe,
+    since there is currently no way to do that.
+    '''
+    setup_logging()
+    logger = logging.getLogger(__name__)
+    df = pd.read_csv(sphinx_file)
+    model_names = []
+    all_energy_channels = []
+    all_observed_thresholds = {}
+
+
+
+    for i in range(len(df)):
+        if df['Model'][i] not in model_names:
+            model_names.append(df['Model'][i])
+        if df['Energy Channel Key'][i] not in all_energy_channels:
+            all_energy_channels.append(df['Energy Channel Key'][i])
+            if df['Threshold Key'][i] not in all_observed_thresholds:
+                all_observed_thresholds[df['Energy Channel Key'][i]] = [df['Threshold Key'][i]]
+    print(model_names, all_energy_channels, all_observed_thresholds)
+    # print('Actually made it here', df)
+    validation_type = ["All", "First", "Last", "Max", "Mean"]
+    for type in validation_type:
+        logger.info("-----------Starting validation of " + type +" forecasts-------------")
+        validation.calculate_intuitive_metrics(df, model_names, all_energy_channels,
+                all_observed_thresholds, type)
+        print('Looping')
+    #Record explanatory information to the log
+    validation.validation_explanation()
+    
+    logger.info("intuitive_validation: Validation process complete.")
+

--- a/sphinxval/utils/post_analysis.py
+++ b/sphinxval/utils/post_analysis.py
@@ -2548,6 +2548,9 @@ def manual_sphinx(sphinx_file):
     '''
     Writing a sub-routine that will run SPHINX validation suite for a pre-existing SPHINX dataframe,
     since there is currently no way to do that.
+    Inputs:
+    sphinx_file: string, the path from the base sphinxval directory to the location of the dataframe
+        that you want to run. 
     '''
     setup_logging()
     logger = logging.getLogger(__name__)
@@ -2565,14 +2568,14 @@ def manual_sphinx(sphinx_file):
             all_energy_channels.append(df['Energy Channel Key'][i])
             if df['Threshold Key'][i] not in all_observed_thresholds:
                 all_observed_thresholds[df['Energy Channel Key'][i]] = [df['Threshold Key'][i]]
-    print(model_names, all_energy_channels, all_observed_thresholds)
+    # print(model_names, all_energy_channels, all_observed_thresholds)
     # print('Actually made it here', df)
     validation_type = ["All", "First", "Last", "Max", "Mean"]
     for type in validation_type:
         logger.info("-----------Starting validation of " + type +" forecasts-------------")
         validation.calculate_intuitive_metrics(df, model_names, all_energy_channels,
                 all_observed_thresholds, type)
-        print('Looping')
+        # print('Looping')
     #Record explanatory information to the log
     validation.validation_explanation()
     


### PR DESCRIPTION
Added a new feature to the post analysis tool - the ability to run sphinx manually for an already existing sphinx dataframe. This is useful in cases where you don't want to go through the sphinx matching process again or don't have access to the model jsons. This runs through the validation workflow (validation.calculate_intuitive_metrics) for all models, energies and thresholds in the dataframe you provide - so its best to create a dataframe that only has what you want to look into in it (clear out models/energies that you don't want) - and creates the normal suite of output files (_selections and _metrics).
To run:
py ./bin/post_analysis.py --manual_run 'path/to/sphinx_dataframe'

